### PR TITLE
Add Mac Command key support for hotkey

### DIFF
--- a/addon/src/js/constants.js
+++ b/addon/src/js/constants.js
@@ -56,6 +56,7 @@ const DEFAULT_OPTIONS = {
             ctrlKey: true,
             shiftKey: false,
             altKey: false,
+            metaKey: false,
             key: '`',
             keyCode: 192,
             action: {
@@ -66,6 +67,7 @@ const DEFAULT_OPTIONS = {
             ctrlKey: true,
             shiftKey: true,
             altKey: false,
+            metaKey: false,
             key: '~',
             keyCode: 192,
             action: {

--- a/addon/src/popup/Popup.vue
+++ b/addon/src/popup/Popup.vue
@@ -469,7 +469,7 @@
                 browser.runtime.reload();
             },
             openManageGroups() {
-                BG.openManageGroups(window.screen);
+                BG.openManageGroups(utils.clone(window.screen));
                 window.close();
             },
             sortGroups(vector) {

--- a/addon/src/web/hotkeys.js
+++ b/addon/src/web/hotkeys.js
@@ -53,7 +53,7 @@ function resetFoundHotKey() {
 }
 
 function checkKey(e) {
-    if (foundHotKey || !e.isTrusted || [KeyEvent.DOM_VK_SHIFT, KeyEvent.DOM_VK_CONTROL, KeyEvent.DOM_VK_ALT].includes(e.keyCode)) { // not track only auxiliary keys
+    if (foundHotKey || !e.isTrusted || [KeyEvent.DOM_VK_SHIFT, KeyEvent.DOM_VK_CONTROL, KeyEvent.DOM_VK_ALT, KeyEvent.DOM_VK_META].includes(e.keyCode)) { // not track only auxiliary keys
         return;
     }
 
@@ -61,6 +61,7 @@ function checkKey(e) {
         if (hotkey.ctrlKey === e.ctrlKey &&
             hotkey.shiftKey === e.shiftKey &&
             hotkey.altKey === e.altKey &&
+            hotkey.metaKey === e.metaKey &&
             (
                 (hotkey.keyCode && hotkey.keyCode === e.keyCode) ||
                 (!hotkey.keyCode && !e.keyCode && hotkey.key.toUpperCase() === e.key.toUpperCase())


### PR DESCRIPTION
Fixed:
 - Mac no longer treat Ctrl as Command for open pop-up, which is now the same as other custom hotkey

New:
 - Mac can use Command as hotkey
 - Mac display alt as option

Screenshot for macOS hotkey setting pages:
![image](https://user-images.githubusercontent.com/40160522/42037308-abe42e08-7b1a-11e8-9a48-705be11b1cdb.png)

As a macOS user, it is inconvenient having no Command Key as hotkey, hope this help.

