### PR TITLE
Fixed message for moving multiple tabs

### DIFF
--- a/addon/src/_locales/en/messages.json
+++ b/addon/src/_locales/en/messages.json
@@ -526,8 +526,8 @@
         }
     },
     "moveMultipleTabsToGroupMessage": {
-        "message": "$tabscount$ tabs has been moved.\nClick here to open the first tab",
-        "description": "$tabscount$ tabs has been moved.\nClick here to open the first tab",
+        "message": "$tabscount$ tabs have been moved.\nClick here to open the first tab",
+        "description": "$tabscount$ tabs have been moved.\nClick here to open the first tab",
         "placeholders": {
             "tabscount": {
                 "content": "$1",


### PR DESCRIPTION
Fixed the message that appears in the notification after moving multiple tabs. Since 'tabs' is plural, 'has' is incorrect.