### PR TITLE
Keep openerTabId of tabs moved across windows

### DIFF
--- a/addon/src/js/tabs.js
+++ b/addon/src/js/tabs.js
@@ -481,6 +481,8 @@
             await utils.wait(100);
         }
 
+        let openerTabIds = options.windowId ? tabs.map(tab => tab.openerTabId) : [];
+
         console.log('Tabs.moveNative before');
 
         let movedTabs = await browser.tabs.move(tabs.map(utils.keyId), options),
@@ -488,9 +490,16 @@
 
         console.log('Tabs.moveNative after');
 
-        return tabs.map(function(tab) {
+        return tabs.map(function(tab, index) {
             if (options.windowId) {
                 tab.windowId = options.windowId;
+                // Tabs moved across windows always lose their openerTabId even
+                // if it is also moved to the same window together, thus we need
+                // to restore it manually.
+                if (openerTabIds[index] > 0) {
+                  tab.openerTabId = openerTabIds[index];
+                  browser.tabs.update(tab.id, { openerTabId: tab.openerTabId });
+                }
             }
 
             if (movedTabsObj[tab.id]) {


### PR DESCRIPTION
After investigations at https://github.com/piroor/treestyletab/issues/2546#issuecomment-733488187 I've realized that `openerTabId` of tabs are cleared by Firefox when they are moved across windows. It may produce broken tree when a group is applied to a new window. This change keeps `openerTabId` information for such tabs and should improve compatibility with other addons providing tree structure based on `openerTabId`, not only Tree Style Tab. How about this change?