### PR TITLE
update deprecated `getURL` method calls

### DIFF
--- a/addon/src/background.js
+++ b/addon/src/background.js
@@ -7,7 +7,7 @@ if (2 == window.localStorage.enableDebug) { // if debug was auto-enabled - disab
 }
 console.restart();
 
-const manageTabsPageUrl = browser.extension.getURL(MANAGE_TABS_URL);
+const manageTabsPageUrl = browser.runtime.getURL(MANAGE_TABS_URL);
 
 let options = {},
     reCreateTabsOnRemoveWindow = [],
@@ -1594,7 +1594,7 @@ const onBeforeTabRequest = utils.catchFunc(async function({tabId, url, originUrl
             let uuid = utils.getUUIDFromUrl(originUrl);
 
             if (!ignoreExtForReopenContainer.has(uuid)) {
-                newTabParams.url = utils.setUrlSearchParams(browser.extension.getURL('/help/open-in-container.html'), {
+                newTabParams.url = utils.setUrlSearchParams(browser.runtime.getURL('/help/open-in-container.html'), {
                     url: tab.url,
                     anotherCookieStoreId: tab.cookieStoreId,
                     uuid: uuid,
@@ -2589,7 +2589,7 @@ window.BG = {
 };
 
 function openHelp(page) {
-    let url = browser.extension.getURL(`/help/${page}.html`);
+    let url = browser.runtime.getURL(`/help/${page}.html`);
     return Tabs.createUrlOnce(url);
 }
 

--- a/addon/src/js/error-handler.js
+++ b/addon/src/js/error-handler.js
@@ -44,7 +44,7 @@
         if (errorData.message === 'An unexpected error occurred') {
             browser.tabs.create({
                 active: true,
-                url: browser.extension.getURL('/help/db-error-reinstall.html'),
+                url: browser.runtime.getURL('/help/db-error-reinstall.html'),
             });
         }
 

--- a/addon/src/js/startup.js
+++ b/addon/src/js/startup.js
@@ -39,7 +39,7 @@
         window.containers = background.containers;
     }
 
-    window.addonUrlPrefix = browser.extension.getURL('');
+    window.addonUrlPrefix = browser.runtime.getURL('');
     window.manifest = browser.runtime.getManifest();
     window.noop = function() {};
 

--- a/addon/src/js/utils.js
+++ b/addon/src/js/utils.js
@@ -31,7 +31,7 @@
                 ...platformInfo,
                 ...browserInfo,
             },
-            UUID: browser.extension.getURL(''),
+            UUID: browser.runtime.getURL(''),
             permissions: {
                 bookmarks: permissionBookmarks,
             },

--- a/addon/src/web/hotkeys.js
+++ b/addon/src/web/hotkeys.js
@@ -173,7 +173,7 @@ function showGroupsPopup(data) {
         groupNode.classList.add('stg-popup-group');
 
         let imgNode = document.createElement('img');
-        imgNode.src = group.iconUrl.startsWith('/icons') ? browser.extension.getURL(group.iconUrl) : group.iconUrl;
+        imgNode.src = group.iconUrl.startsWith('/icons') ? browser.runtime.getURL(group.iconUrl) : group.iconUrl;
 
         let figureNode = document.createElement('figure');
         figureNode.classList = 'group-icon';
@@ -200,7 +200,7 @@ function showGroupsPopup(data) {
             let archiveImgNode = document.createElement('img');
 
             archiveImgNode.classList = 'archive-icon';
-            archiveImgNode.src = browser.extension.getURL('/icons/archive.svg');
+            archiveImgNode.src = browser.runtime.getURL('/icons/archive.svg');
 
             groupNode.append(archiveImgNode);
         }*/
@@ -293,7 +293,7 @@ function showGroupsPopup(data) {
         let newGroupNode = createGroupNode({
             id: 'new',
             title: browser.i18n.getMessage('createNewGroup'),
-            iconUrl: browser.extension.getURL('/icons/group-new.svg'),
+            iconUrl: browser.runtime.getURL('/icons/group-new.svg'),
         }, true);
 
         // newGroupNode.style.justifyContent = 'center';

--- a/plugins/stg-plugin-create-new-tab/background.js
+++ b/plugins/stg-plugin-create-new-tab/background.js
@@ -153,7 +153,7 @@
     // https://dxr.mozilla.org/mozilla-central/source/browser/components/contextualidentity/content
     async function getIcon(container) {
         if (!container) {
-            return browser.extension.getURL('/icons/icon.svg');
+            return browser.runtime.getURL('/icons/icon.svg');
         }
 
         let {icon, colorCode, cookieStoreId} = container,

--- a/plugins/stg-plugin-group-notes/background.js
+++ b/plugins/stg-plugin-group-notes/background.js
@@ -53,7 +53,7 @@
             browser.tabs.create({
                 active: true,
                 pinned: true,
-                url: browser.extension.getURL('popup/popup.html#tab'),
+                url: browser.runtime.getURL('popup/popup.html#tab'),
             });
         },
         contexts: ['browser_action'],


### PR DESCRIPTION
This PR just updates deprecated `browser.extension.getURL` calls to `browser.runtime.getURL`