### PR TITLE
Add user option for disabling notifications when using private browsing

### DIFF
--- a/addon/src/_locales/bg/messages.json
+++ b/addon/src/_locales/bg/messages.json
@@ -453,6 +453,10 @@
         "message": "Обновяване на миниатюрата на раздела",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Не показвайте известия за грешки, когато не се намират нормални прозорци (например в частен/инкогнито режим)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Грешка: не са намерени обикновени или поверителни/инкогнито/изскачащи прозорци.\nДобавката е спряла да работи. Рестартирайте мрежовия четец.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/cs_CZ/messages.json
+++ b/addon/src/_locales/cs_CZ/messages.json
@@ -421,6 +421,10 @@
         "message": "Aktualizovat náhled panelu",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Nezobrazujte oznámení o chybách, pokud nejsou nalezena normální okna (např. V režimu soukromého/inkognito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Chyba: nenalezeno žádné normální okno, ale pouze anonymní nebo vyskakovací.\nDoplněk přestal fungovat. Prosím, restartujte prohlížeč.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/de/messages.json
+++ b/addon/src/_locales/de/messages.json
@@ -445,6 +445,10 @@
         "message": "Aktualisiere das Vorschaubild dieses Tabs",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Keine Fehlermeldungen anzeigen, wenn normale Fenster nicht gefunden werden (z. B. im privaten/Inkognito-Modus)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Fehler: Es wurden keine normalen nicht privaten/Inkognito/Popup-Fenster gefunden.\nAdd-On funktioniert nicht mehr - bitte den Browser neu starten.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/en/messages.json
+++ b/addon/src/_locales/en/messages.json
@@ -457,6 +457,10 @@
         "message": "Update thumbnail for this tab",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/es_AR/messages.json
+++ b/addon/src/_locales/es_AR/messages.json
@@ -437,6 +437,10 @@
         "message": "Actualizar miniatura de esta pestaña",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "No muestre notificaciones de error cuando no se encuentran ventanas normales (por ejemplo, en modo privado/de incógnito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Error: no se encontró ninguna ventana normal no privada/incógnita/emergente.\nLa extensión se detuvo. Por favor, reinicia el navegador.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/es_ES/messages.json
+++ b/addon/src/_locales/es_ES/messages.json
@@ -445,6 +445,10 @@
         "message": "Actualizar la miniatura de esta pestaña",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "No muestre notificaciones de error cuando no se encuentran ventanas normales (por ejemplo, en modo privado/de incógnito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Error: no se encontró ninguna pestaña normal que no sea privada/de incógnito/emergente.\nEl complemento ha dejado de funcionar. Por favor, reinicie el navegador.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/fr/messages.json
+++ b/addon/src/_locales/fr/messages.json
@@ -449,6 +449,10 @@
         "message": "Mettre à jour la capture de cet onglet",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Ne pas afficher les notifications d'erreur lorsque les fenêtres normales sont introuvables (par exemple en mode privé/incognito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Erreur : aucun onglet normal n'a été trouvé (ni privé, ni navigation privée, ni fenêtre pop-up). L'extension a cessé de fonctionner. Veuillez redémarrer le navigateur.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/id/messages.json
+++ b/addon/src/_locales/id/messages.json
@@ -437,6 +437,10 @@
         "message": "Perbarui gambar mini untuk tab ini",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Jangan tampilkan pemberitahuan kesalahan ketika jendela normal tidak ditemukan (misalnya dalam mode pribadi/penyamaran)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Kesalahan: tidak ditemukan jendela tidak pribadi/penyamaran/popup normal.\nAddon berhenti bekerja. Silakan, restart browser.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/it/messages.json
+++ b/addon/src/_locales/it/messages.json
@@ -437,6 +437,10 @@
         "message": "Aggiorna l'anteprima per questa scheda",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Non visualizzare le notifiche di errore quando non vengono trovate le finestre normali (ad esempio in modalità privata/in incognito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Errore: non è stato possibile trovare nessuna finestra privata, in incognito o pop-up.\nL'estensione ha smesso di funzionare correttamente. Per favore, riavviare il browser.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/ja/messages.json
+++ b/addon/src/_locales/ja/messages.json
@@ -425,6 +425,10 @@
         "message": "このタブのサムネイルを更新する",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "通常のウィンドウが見つからない場合 (プライベート/シークレット モードなど) にエラー通知を表示しません。",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "エラー: 通常のウィンドウ (非プライベート / 匿名 / ポップアップ) が見つかりませんでした。\nアドオンが動作を停止しました。ブラウザーを再起動してください。",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/ko/messages.json
+++ b/addon/src/_locales/ko/messages.json
@@ -425,6 +425,10 @@
         "message": "이 탭의 미리보기 이미지 업데이트",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "일반 창을 찾을 수 없을 때(예: 개인/시크릿 모드) 오류 알림을 표시하지 않습니다.",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "오류: 비공개/시크릿/팝업이 아닌 일반 창을 찾을 수 없습니다.\n애드온이 작동을 멈췄습니다. 브라우저를 다시 시작해 주세요.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/nl/messages.json
+++ b/addon/src/_locales/nl/messages.json
@@ -453,6 +453,10 @@
         "message": "Voorbeeld van deze tab bijwerken",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Geef geen foutmeldingen weer als normale vensters niet worden gevonden (bijvoorbeeld in privé-/incognitomodus)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Fout: geen enkel normaal (niet: privé/incognito/pop-up) venster gevonden.\nAdd-on is gestopt met werken. Herstart de browser a.u.b.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/pl/messages.json
+++ b/addon/src/_locales/pl/messages.json
@@ -445,6 +445,10 @@
         "message": "Zaktualizuj miniaturę dla tej karty",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Nie wyświetlaj powiadomień o błędach, gdy nie znaleziono normalnego okna (np. w trybie prywatnym/incognito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Błąd: nie znaleziono żadnych okien typu nie prywatne, pop-up lub incognito\nDodatek przestał działać. Uruchom ponownie przeglądarkę.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/pt_BR/messages.json
+++ b/addon/src/_locales/pt_BR/messages.json
@@ -445,6 +445,10 @@
         "message": "Atualizar miniatura desta aba",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Não exibir notificações de erro quando janelas normais não forem encontradas (por exemplo, no modo privado/incógnito)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Erro: não foi encontrada nenhuma janela normal não privativa/incógnito/pop-up.\nExtensão parou de funcionar. Por favor, reinicie o navegador.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/ru/messages.json
+++ b/addon/src/_locales/ru/messages.json
@@ -453,6 +453,10 @@
         "message": "Обновить эскиз для этой вкладки",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Не отображать уведомления об ошибках, если не найдены обычные окна (например, в приватном режиме/режиме инкогнито).",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Ошибка: не найдено нормальных окон, только приватные или всплывающие. Дополнение прекращает работу.\nПожалуйста, перезагрузите браузер.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/uk/messages.json
+++ b/addon/src/_locales/uk/messages.json
@@ -453,6 +453,10 @@
         "message": "Оновити ескіз для цієї вкладки",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "Не відображати сповіщення про помилки, коли звичайні вікна не знайдені (наприклад, у приватному режимі/режимі анонімного перегляду)",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "Помилка: не знайдено звичайних вікон, тільки приватні або спливаючі. Доповнення припиняє роботу.\nБудь ласка, перезавантажте браузер.",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/zh_CN/messages.json
+++ b/addon/src/_locales/zh_CN/messages.json
@@ -445,6 +445,10 @@
         "message": "更新该标签页的缩略图",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "未找到正常窗口时不显示错误通知（例如在私人/隐身模式下）",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "错误：未找到正常的非隐私/匿名/弹出窗口。扩展停止工作，请重启浏览器。",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/_locales/zh_TW/messages.json
+++ b/addon/src/_locales/zh_TW/messages.json
@@ -449,6 +449,10 @@
         "message": "更新此分頁之縮圖",
         "description": "Update thumbnail for this tab"
     },
+    "disableWindowNotFoundNotifications": {
+        "message": "未找到正常視窗時不顯示錯誤通知（例如在私人/隱身模式下）",
+        "description": "Do not display error notifications when normal windows are not found (e.g. in private/incognito mode)"
+    },
     "notFoundWindowsAddonStoppedWorking": {
         "message": "錯誤：找不到任何正常的非隱私/匿名/彈出窗。\n附加元件停止運作，請重新啟動瀏覽器。",
         "description": "Error: not found any normal not private/incognito/popup windows.\nAddon stopped working. Please, restart browser."

--- a/addon/src/js/constants.js
+++ b/addon/src/js/constants.js
@@ -275,6 +275,7 @@ export const DEFAULT_OPTIONS = Object.freeze({
 
     closePopupAfterChangeGroup: true,
     closePopupAfterSelectTab: false,
+    disableWindowNotFoundNotifications: false,
     openGroupAfterChange: false,
     alwaysAskNewGroupName: true,
     createNewGroupWhenOpenNewWindow: false,

--- a/addon/src/options/Options.vue
+++ b/addon/src/options/Options.vue
@@ -755,6 +755,12 @@
             </div>
             <div class="field">
                 <label class="checkbox">
+                    <input v-model="options.disableWindowNotFoundNotifications" type="checkbox" />
+                    <span v-text="lang('disableWindowNotFoundNotifications')"></span>
+                </label>
+            </div>
+            <div class="field">
+                <label class="checkbox">
                     <input v-model="options.showTabsWithThumbnailsInManageGroups" type="checkbox" />
                     <span v-text="lang('showTabsWithThumbnailsInManageGroups')"></span>
                 </label>

--- a/addon/src/stg-background.js
+++ b/addon/src/stg-background.js
@@ -4131,7 +4131,9 @@ async function init() {
         if (!windows.length) {
             log.error('no windows found');
             window.localStorage.notFoundWindowsAddonStoppedWorking = 1;
-            Utils.notify(['notFoundWindowsAddonStoppedWorking']);
+            if(false == options.disableWindowNotFoundNotifications) {
+                Utils.notify(['notFoundWindowsAddonStoppedWorking']);
+            }
             browser.windows.onCreated.addListener(() => browser.runtime.reload());
             throw '';
         } else if (window.localStorage.notFoundWindowsAddonStoppedWorking) {


### PR DESCRIPTION
### Summary

Small change to allow users to turn off the notification about private browsing, as it can be annoying when one is working in private browsing mode.

### Problem:

Currently, it is very annoying to have STG installed (for normal browsing) and then open Firefox/Librewolf in a private browsing session due to the error notification that is displayed every time the user opens a new window. Certain addons that open dialog windows, such as [DownThemAll](https://addons.mozilla.org/en-US/firefox/addon/downthemall/), also trigger STG's error notification (when used in private browsing mode). So depending on what addons the user has, what they are doing, and how frequently they open new private browsing windows, the user could potentially be seeing this notification *MUCH* more frequently than simply once per day.

### Notification Text: 

> Error: Error: not found any normal not private/incognito/popup windows.
>
> Addon stopped working. Please, restart browser.

### Screenshots:

Target Notification:

![stg-private-browsing-notification](https://github.com/Drive4ik/simple-tab-groups/assets/166459541/12cb1111-aa5f-4f42-836e-82464fb31a94)

What this change adds:

![stg-new-option](https://github.com/Drive4ik/simple-tab-groups/assets/166459541/9bb94656-887c-4dca-a42a-e5a3f408cd59)

### Code Description:

As the current version of STG does not even allow using the addon in private browsing anyway, it is debatable whether it even makes sense to have this error notification displayed at all. But that is not a decision for me to make and is outside the scope of this PR.

Instead, this PR aims simply to give the user a way to disable that specific error notification by providing a checkbox on the STG options page. The default is unchecked (false) which has the same behavior as STG currently has, simply incase the error is desired / to help users initially realize that STG doesn't work in private session.

If user checks the checkbox (true), then the notification no longer appears. Internally, the addon still throws an exception and handles everything else the same, only the notification is skipped.

Only the logic for the notification mentioned above is modified (other notifications are unaffected, only the handling for this specific one is different).

Since I only know English, the other locale messages are google translations. See the new `"disableWindowNotFoundNotifications"` string under `
addon/src/_locales/*/messages.json` files.

### Builds / testing

I am on Fedora Linux and built the project using the following:

```bash
$ cd addons
$ npm install && npm run build && npm run build-zip
```

After an initial test build on the master branch to confirm there were no issues with the build on my setup, I switched to my change branch and rebuilt.

I have not looked into the signing process yet and Firefox 124.0.1 would not allow me to install due to the build being unsigned. However, in [LibreWolf](https://librewolf.net/) 124.0.1 (a popular firefox fork), I was able to set `xpinstall.signatures.required=false` and install there. After install, I confirmed that the notification is still present in private browsing (e.g. current behavior) by default / while the checkbox is unchecked, then, after checking the option, that the notification is no longer displayed.