### PR TITLE
added option for user to completely disable all notifications

### DIFF
--- a/addon/src/_locales/bg/messages.json
+++ b/addon/src/_locales/bg/messages.json
@@ -715,6 +715,10 @@
         "message": "Показване на известие след изтриване на група",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Напълно деактивирайте всички известия (забележка: това може да скрие важни предупреждения/грешки)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Презареждане на раздела",
         "description": "Reload tab"

--- a/addon/src/_locales/cs_CZ/messages.json
+++ b/addon/src/_locales/cs_CZ/messages.json
@@ -671,6 +671,10 @@
         "message": "Ukázat upozornění po smazání skupiny",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Zcela deaktivujte všechna upozornění (poznámka: toto může skrýt důležitá varování/chyby)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Obnovit panel",
         "description": "Reload tab"

--- a/addon/src/_locales/de/messages.json
+++ b/addon/src/_locales/de/messages.json
@@ -707,6 +707,10 @@
         "message": "Benachrichtigung anzeigen, nachdem Gruppe gelöscht wurde",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Deaktivieren Sie alle Benachrichtigungen vollständig (Hinweis: Dadurch werden möglicherweise wichtige Warnungen/Fehler ausgeblendet)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Tab neu laden",
         "description": "Reload tab"

--- a/addon/src/_locales/en/messages.json
+++ b/addon/src/_locales/en/messages.json
@@ -719,6 +719,10 @@
         "message": "Show notification after group delete",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Completely disable all notifications (note: this may hide important warnings/errors)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Reload tab",
         "description": "Reload tab"

--- a/addon/src/_locales/es_AR/messages.json
+++ b/addon/src/_locales/es_AR/messages.json
@@ -691,6 +691,10 @@
         "message": "Mostrar notificación tras la eliminación de un grupo",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Desactive completamente todas las notificaciones (nota: esto puede ocultar advertencias/errores importantes)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Recargar pestaña",
         "description": "Reload tab"

--- a/addon/src/_locales/es_ES/messages.json
+++ b/addon/src/_locales/es_ES/messages.json
@@ -707,6 +707,10 @@
         "message": "Mostrar una notificación luego de borrar un grupo",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Desactive completamente todas las notificaciones (nota: esto puede ocultar advertencias/errores importantes)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Recargar pestaña",
         "description": "Reload tab"

--- a/addon/src/_locales/fr/messages.json
+++ b/addon/src/_locales/fr/messages.json
@@ -711,6 +711,10 @@
         "message": "Afficher une notification après la suppression d'un groupe",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Désactivez complètement toutes les notifications (remarque : cela peut masquer des avertissements/erreurs importants)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Recharger l'onglet",
         "description": "Reload tab"

--- a/addon/src/_locales/id/messages.json
+++ b/addon/src/_locales/id/messages.json
@@ -691,6 +691,10 @@
         "message": "Tampilkan notifikasi setelah grup dihapus",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Nonaktifkan sepenuhnya semua notifikasi (catatan: ini mungkin menyembunyikan peringatan/kesalahan penting)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Muat ulang tab",
         "description": "Reload tab"

--- a/addon/src/_locales/it/messages.json
+++ b/addon/src/_locales/it/messages.json
@@ -691,6 +691,10 @@
         "message": "Mostra una notifica dopo che un gruppo è stato eliminato",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Disattiva completamente tutte le notifiche (nota: ciò potrebbe nascondere avvisi/errori importanti)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Ricarica la scheda",
         "description": "Reload tab"

--- a/addon/src/_locales/ja/messages.json
+++ b/addon/src/_locales/ja/messages.json
@@ -679,6 +679,10 @@
         "message": "グループの削除時に通知を表示する",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "すべての通知を完全に無効にします (注: これにより、重要な警告/エラーが非表示になる可能性があります)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "タブを再読み込み",
         "description": "Reload tab"

--- a/addon/src/_locales/ko/messages.json
+++ b/addon/src/_locales/ko/messages.json
@@ -679,6 +679,10 @@
         "message": "그룹 삭제 후 알림 표시",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "모든 알림을 완전히 비활성화합니다(참고: 중요한 경고/오류가 숨겨질 수 있음).",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "탭 새로고침",
         "description": "Reload tab"

--- a/addon/src/_locales/nl/messages.json
+++ b/addon/src/_locales/nl/messages.json
@@ -715,6 +715,10 @@
         "message": "Toon notificatie na het verwijderen van een groep",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Schakel alle meldingen volledig uit (let op: dit kan belangrijke waarschuwingen/fouten verbergen)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Tab vernieuwen",
         "description": "Reload tab"

--- a/addon/src/_locales/pl/messages.json
+++ b/addon/src/_locales/pl/messages.json
@@ -707,6 +707,10 @@
         "message": "Pokaż powiadomienie po usunięciu grupy",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Całkowicie wyłącz wszystkie powiadomienia (uwaga: może to ukryć ważne ostrzeżenia/błędy)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Odśwież kartę",
         "description": "Reload tab"

--- a/addon/src/_locales/pt_BR/messages.json
+++ b/addon/src/_locales/pt_BR/messages.json
@@ -699,6 +699,10 @@
         "message": "Mostrar notificação após exclusão do grupo",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Desative completamente todas as notificações (nota: isso pode ocultar avisos/erros importantes)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Recarregar aba",
         "description": "Reload tab"

--- a/addon/src/_locales/ru/messages.json
+++ b/addon/src/_locales/ru/messages.json
@@ -715,6 +715,10 @@
         "message": "Показать уведомление после удаления группы",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Полностью отключите все уведомления (примечание: это может скрыть важные предупреждения/ошибки)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Обновить вкладку",
         "description": "Reload tab"

--- a/addon/src/_locales/uk/messages.json
+++ b/addon/src/_locales/uk/messages.json
@@ -715,6 +715,10 @@
         "message": "Показати повідомлення після видалення групи",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "Повністю вимкнути всі сповіщення (примітка: це може приховати важливі попередження/помилки)",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "Оновити вкладку",
         "description": "Reload tab"

--- a/addon/src/_locales/zh_CN/messages.json
+++ b/addon/src/_locales/zh_CN/messages.json
@@ -699,6 +699,10 @@
         "message": "删除群组后显示通知",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "完全禁用所有通知（注意：这可能会隐藏重要的警告/错误）",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "重新加载标签页",
         "description": "Reload tab"

--- a/addon/src/_locales/zh_TW/messages.json
+++ b/addon/src/_locales/zh_TW/messages.json
@@ -711,6 +711,10 @@
         "message": "群組刪除後顯示通知",
         "description": "Show notification after group delete"
     },
+    "disableAllNotifications": {
+        "message": "完全禁用所有通知（注意：这可能会隐藏重要的警告/错误）",
+        "description": "Completely disable all notifications (note: this may hide important warnings/errors)"
+    },
     "reloadTab": {
         "message": "重新載入分頁",
         "description": "Reload tab"

--- a/addon/src/js/constants.js
+++ b/addon/src/js/constants.js
@@ -282,6 +282,7 @@ export const DEFAULT_OPTIONS = Object.freeze({
     showConfirmDialogBeforeGroupArchiving: true,
     showConfirmDialogBeforeGroupDelete: true,
     showNotificationAfterGroupDelete: true,
+    disableAllNotifications: false,
     showContextMenuOnTabs: true,
     showContextMenuOnLinks: true,
     defaultBookmarksParent: DEFAULT_BOOKMARKS_PARENTS[0],

--- a/addon/src/js/utils.js
+++ b/addon/src/js/utils.js
@@ -1,4 +1,4 @@
-
+import backgroundSelf from './background.js';
 import * as Constants from './constants.js';
 import JSON from './json.js';
 
@@ -138,6 +138,12 @@ export function sliceText(text, length = 50) {
 }
 
 export async function notify(message, sec = 20, id = null, iconUrl = null, onClick = null, onClose = null) {
+	try {
+		if (backgroundSelf.options.disableAllNotifications) {
+			return;
+		}
+	} catch(err) { /* ignore */ }
+
     if (id) {
         await browser.notifications.clear(id);
     } else {

--- a/addon/src/options/Options.vue
+++ b/addon/src/options/Options.vue
@@ -755,6 +755,12 @@
             </div>
             <div class="field">
                 <label class="checkbox">
+                    <input v-model="options.disableAllNotifications" type="checkbox" />
+                    <span v-text="lang('disableAllNotifications')"></span>
+                </label>
+            </div>
+            <div class="field">
+                <label class="checkbox">
                     <input v-model="options.showTabsWithThumbnailsInManageGroups" type="checkbox" />
                     <span v-text="lang('showTabsWithThumbnailsInManageGroups')"></span>
                 </label>


### PR DESCRIPTION
### Problem Summary

Currently, while STG does not work in private browsing mode, if the addon is simply installed and active, it will still generate notification messages. Those message are displayed not only at browser launch but also every time any other addons (e.g. like [DownThemAll](https://addons.mozilla.org/en-US/firefox/addon/downthemall/)) open their own windows. I quickly grew to find this behavior annoying.

Originally, I had made a patch/PR [here](https://github.com/Drive4ik/simple-tab-groups/pull/1161) to simply turn off that 1 notification. But after further testing, I found I would still get other notifications whenever I used a private browsing session.

## Change Summary

This is a small change that simply gives the user a checkbox where they can disable all notifications. The checkbox is NOT enabled/checked by default (e.g. STG will behave as it always has unless the user specifically checks the box). But doing so makes the occasional private browsing session much more enjoyable. Aside from private browsing, this can also serve as an override that allows users to turn off all notifications from a central location instead of having to select multiple values.

Mostly this is applied in `addon/src/js/utils.js` by adding an import + a check in the `notify` function. If the boolean is set, the function will always pass the check and returns without generating any notification messages.


### Notification Text: 

> Error: Error: not found any normal not private/incognito/popup windows.
>
> Addon stopped working. Please, restart browser.

### Screenshots:

example of notifications seen during private browsing :

![stg-private-browsing-notification](https://github.com/Drive4ik/simple-tab-groups/assets/166459541/12cb1111-aa5f-4f42-836e-82464fb31a94)

What this change adds:

![new-stg-option](https://github.com/Drive4ik/simple-tab-groups/assets/166459541/34b0efc4-c39c-46b1-a644-ee10b1cbb404)

### Builds / testing

I am on Fedora Linux and built the project using the following:

```bash
$ cd addons
$ npm install && npm run build && npm run build-zip
```

I have tested my build in LibreWolf (using `xpinstall.signatures.required=false`) with no issues. By that, I mean that I confirmed the existing behavior in both the original addon and then again in my build, then checked the new option and confirmed that I was no longer getting notification messages.
