### PR TITLE
fix: ignore errors from menus.remove and menus.update

### DIFF
--- a/addon/src/js/menus.js
+++ b/addon/src/js/menus.js
@@ -69,7 +69,9 @@ export async function remove(id) {
         return;
     }
 
-    await browser.menus.remove(id);
+    try {
+        await browser.menus.remove(id);
+    } catch(e) {}
 
     browser.menus.onClicked.removeListener(menusMap.get(id).onMenuClick);
     menusMap.delete(id);
@@ -85,7 +87,9 @@ export async function update(id, updateProperties) {
         return;
     }
 
-    await browser.menus.update(id, updateProperties);
+    try {
+        await browser.menus.update(id, updateProperties);
+    } catch(e) {}
 
     // log.stop();
 }


### PR DESCRIPTION
Fixes #1242

I'm not sure if this is the whole fix, but it seems to get things back to normal.