### PR TITLE
fix for fix

### DIFF
--- a/addon/src/js/constants.js
+++ b/addon/src/js/constants.js
@@ -14,7 +14,7 @@ export const TEMPORARY_CONTAINER = 'temporary-container';
 export const TEMPORARY_CONTAINER_ICON = 'chill';
 
 export const DEFAULT_COOKIE_STORE_ID = await browser.cookies?.getAllCookieStores()
-    .then(stores => stores.find(store => store.id.includes('default')).id) ?? 'firefox-default';
+    .then(stores => stores.find(store => store.id.includes('default'))?.id) ?? 'firefox-default';
 
 export const CONTEXT_MENU_PREFIX_UNDO_REMOVE_GROUP = 'stg-undo-remove-group-id-';
 


### PR DESCRIPTION
Previous commit 8ce9a84e411bc8faf0da341d3e4bcf94e4cbcae8 with fix to support IceCat completely bricked the extension for me because there were no cookie store with word "default" in it's id (everything is in containers). This is a fix for that fix.