### PR TITLE
fix: Update broken MDN links to new URL structure

### DIFF
--- a/addon/src/js/notification.js
+++ b/addon/src/js/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/modules/notification.js
+++ b/plugins/modules/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-create-new-group/notification.js
+++ b/plugins/stg-plugin-create-new-group/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-create-new-tab/notification.js
+++ b/plugins/stg-plugin-create-new-tab/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-create-temp-tab/notification.js
+++ b/plugins/stg-plugin-create-temp-tab/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-del-current-group/notification.js
+++ b/plugins/stg-plugin-del-current-group/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-group-notes/notification.js
+++ b/plugins/stg-plugin-group-notes/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-load-custom-group/notification.js
+++ b/plugins/stg-plugin-load-custom-group/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',

--- a/plugins/stg-plugin-manage-groups/notification.js
+++ b/plugins/stg-plugin-manage-groups/notification.js
@@ -129,7 +129,7 @@ Notification.addListeners = addListeners;
 Notification.removeListeners = removeListeners;
 
 async function create({id, iconUrl, title, message}) {
-    // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions
     // Only 'type', 'iconUrl', 'title', and 'message' are supported.
     return await browser.notifications.create(wrapId(id), {
         type: 'basic',


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates broken MDN links to the new URL structure.

Fixed: /en-US/Add-ons/WebExtensions/API/notifications/NotificationOptions → /en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/NotificationOptions (9 occurrences)